### PR TITLE
Minor fixes (investigate scene transition)

### DIFF
--- a/Assets/_schwer/Crafting/Scripts/CraftingManager.cs
+++ b/Assets/_schwer/Crafting/Scripts/CraftingManager.cs
@@ -143,13 +143,13 @@ namespace Schwer.ItemSystem {
 
                     discoveredRecipes.Add(recipes[i].id);
 
-                    FindObjectOfType<AudioManager>().Play("Achieve");
+                    AudioManager.instance?.Play("Achieve");
                     Debug.Log($"Crafted {recipes[i].outputAmount}x {recipes[i].output.name}!");
                     return;
                 }
             }
 
-            FindObjectOfType<AudioManager>().Play("Oink");
+            AudioManager.instance?.Play("Oink");
             Debug.Log($"The ingredients didn't yield anything...");
         }
 

--- a/Assets/_schwer/Crafting/Scripts/CraftingManager.cs
+++ b/Assets/_schwer/Crafting/Scripts/CraftingManager.cs
@@ -143,13 +143,13 @@ namespace Schwer.ItemSystem {
 
                     discoveredRecipes.Add(recipes[i].id);
 
-                    AudioManager.instance?.Play("Achieve");
+                    AudioManager.Instance.Play("Achieve");
                     Debug.Log($"Crafted {recipes[i].outputAmount}x {recipes[i].output.name}!");
                     return;
                 }
             }
 
-            AudioManager.instance?.Play("Oink");
+            AudioManager.Instance.Play("Oink");
             Debug.Log($"The ingredients didn't yield anything...");
         }
 

--- a/Assets/cwg/Prefabs cwgpm/keyBox.prefab
+++ b/Assets/cwg/Prefabs cwgpm/keyBox.prefab
@@ -67,7 +67,6 @@ GameObject:
   m_Component:
   - component: {fileID: 1296582202303517434}
   - component: {fileID: 1296582202303517435}
-  - component: {fileID: 1296582202303517412}
   - component: {fileID: 1296582202303517432}
   - component: {fileID: 1296582202303517433}
   - component: {fileID: 1296582202303517439}
@@ -145,23 +144,6 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
---- !u!114 &1296582202303517412
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1296582202303517413}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: c9018cdd690b4434e8f47c54913a9f59, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  playerInRange: 0
-  isShowing: 0
-  dialogBox: {fileID: 0}
-  dialogText: {fileID: 0}
-  dialog: An adequately sized attache.
 --- !u!61 &1296582202303517432
 BoxCollider2D:
   m_ObjectHideFlags: 0
@@ -245,12 +227,13 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 103f1f1a7c7a3422e9671f66f95955b8, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  playerInRange: 0
   thisDoorType: 1
   open: 0
-  playerInventory: {fileID: 11400000, guid: eed34757efe8149009b05f2391e1c1fa, type: 2}
+  storedOpen: {fileID: 0}
+  _inventory: {fileID: 0}
+  item: {fileID: 0}
+  key: {fileID: 0}
   physicsCollider: {fileID: 1296582202035780204}
-  contents: {fileID: 0}
   raiseItem: {fileID: 11400000, guid: 7613166bb78374e3d9108a061150134e, type: 2}
   dialogBox: {fileID: 0}
   dialogText: {fileID: 0}

--- a/Assets/cwg/Sounds/AudioManager.cs
+++ b/Assets/cwg/Sounds/AudioManager.cs
@@ -38,26 +38,32 @@ public class AudioManager : DDOLSingleton<AudioManager>
         }
     */
 
-    public void Play(string name)
+    private Sound FindSound(string name)
     {
         Sound s = Array.Find(sounds, sound => sound == null ? false : sound.name == name);
         if (s == null)
         {
-            Debug.Log("sound not found");
-            return;
+            Debug.Log($"Sound '{name}' not found.");
         }
-        if (s.source == null)
+        else if (s.source == null)
         {
-            Debug.Log("source not found");
-            return;
+            Debug.Log($"Sound source '{name}' not found.");
         }
         else
         {
-            s.source.Play();
-
+            return s;
         }
-        //turns volume on
 
+        return null;
+    }
+
+    public void Play(string name)
+    {
+        var s = FindSound(name);
+        if (s == null) return;
+
+        s.source.Play();
+        //turns volume on
         s.source.volume = s.volume * (1);
     }
 
@@ -65,37 +71,20 @@ public class AudioManager : DDOLSingleton<AudioManager>
     {
         if (!themePlaying)
         {
-            Sound s = Array.Find(sounds, sound => sound == null ? false : sound.name == name);
-            if (s == null)
-            {
-                Debug.Log("sound not found");
-                return;
-            }
-            if (s.source == null)
-            {
-                Debug.Log("source not found");
-                return;
-            }
-            else
-            {
-                s.source.Play();
-                themePlaying = true;
+            var s = FindSound(name);
+            if (s == null) return;
 
-            }
+            s.source.Play();
+            themePlaying = true;
             //turns volume on
-
             s.source.volume = s.volume * (1);
         }
     }
 
     public void Stop(string name)
     {
-        Sound s = Array.Find(sounds, sound => sound.name == name);
-        if (s == null)
-        {
-            Debug.Log("sound not found");
-            return;
-        }
+        var s = FindSound(name);
+        if (s == null) return;
 
         //make sound stop  IMMEDIATELY after leaving zone
         s.source.volume = s.volume * (0);
@@ -110,12 +99,8 @@ public class AudioManager : DDOLSingleton<AudioManager>
 
     public void Fade(string name)
     {
-        Sound s = Array.Find(sounds, sound => sound.name == name);
-        if (s == null)
-        {
-            Debug.Log("sound not found");
-            return;
-        }
+        var s = FindSound(name);
+        if (s == null) return;
 
         if (fades.ContainsKey(name))
         { // if this sound is already being faded

--- a/Assets/cwg/Sounds/AudioManager.cs
+++ b/Assets/cwg/Sounds/AudioManager.cs
@@ -1,28 +1,20 @@
-﻿using UnityEngine.Audio;
-using UnityEngine;
+﻿using UnityEngine;
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using Schwer;
 
-public class AudioManager : MonoBehaviour
+public class AudioManager : DDOLSingleton<AudioManager>
 {
     public Sound[] sounds;
 
     private bool themePlaying;
-    public static AudioManager instance;
     Dictionary<string, Coroutine> fades = new Dictionary<string, Coroutine>();
 
     // Start is called before the first frame update
-    void Awake()
+    protected override void Awake()
     {
-        if (instance == null)
-            instance = this;
-        else
-        {
-            Destroy(gameObject);
-            return;
-        }
-        DontDestroyOnLoad(gameObject);
+        base.Awake();
 
         foreach (Sound s in sounds)
         {

--- a/Assets/cwg/Sounds/AudioManager.cs
+++ b/Assets/cwg/Sounds/AudioManager.cs
@@ -11,7 +11,6 @@ public class AudioManager : DDOLSingleton<AudioManager>
     private bool themePlaying;
     Dictionary<string, Coroutine> fades = new Dictionary<string, Coroutine>();
 
-    // Start is called before the first frame update
     protected override void Awake()
     {
         base.Awake();
@@ -30,16 +29,16 @@ public class AudioManager : DDOLSingleton<AudioManager>
             s.source.loop = s.loop;
         }
     }
-/*
-    void Start()
-    {
-        //change theme according to scene
-        Play("Theme");
-        Debug.Log("theme should play btw");
-    }
-*/
+    /*
+        void Start()
+        {
+            //change theme according to scene
+            Play("Theme");
+            Debug.Log("theme should play btw");
+        }
+    */
 
-    public void Play (string name)
+    public void Play(string name)
     {
         Sound s = Array.Find(sounds, sound => sound == null ? false : sound.name == name);
         if (s == null)
@@ -52,20 +51,19 @@ public class AudioManager : DDOLSingleton<AudioManager>
             Debug.Log("source not found");
             return;
         }
-        else {
-        s.source.Play();
+        else
+        {
+            s.source.Play();
 
         }
         //turns volume on
 
         s.source.volume = s.volume * (1);
-
-
     }
 
     public void PlayTheme(string name)
     {
-        if(!themePlaying)
+        if (!themePlaying)
         {
             Sound s = Array.Find(sounds, sound => sound == null ? false : sound.name == name);
             if (s == null)
@@ -88,7 +86,6 @@ public class AudioManager : DDOLSingleton<AudioManager>
 
             s.source.volume = s.volume * (1);
         }
-
     }
 
     public void Stop(string name)
@@ -102,8 +99,6 @@ public class AudioManager : DDOLSingleton<AudioManager>
 
         //make sound stop  IMMEDIATELY after leaving zone
         s.source.volume = s.volume * (0);
-        
-
     }
 
     /*
@@ -133,10 +128,7 @@ public class AudioManager : DDOLSingleton<AudioManager>
         // start a new fade operation
         Coroutine fadeCoroutine = StartCoroutine(fadeSoundCo(s, 1.5f, name));
         // track it in the map
-    fades.Add(name, fadeCoroutine);
-
-
-
+        fades.Add(name, fadeCoroutine);
     }
 
     IEnumerator fadeSoundCo(Sound sound, float durationSeconds, string name)
@@ -155,7 +147,6 @@ public class AudioManager : DDOLSingleton<AudioManager>
             yield return null;
         }
     }
-
 }
 
 /* this does something really fucking cool and weird

--- a/Assets/cwg/Sounds/AudioZoneManager.cs
+++ b/Assets/cwg/Sounds/AudioZoneManager.cs
@@ -28,7 +28,7 @@ public class AudioZoneManager : MonoBehaviour
         var player = other.GetComponent<CharacterController2D>();
         if (player != null)
         {
-            AudioManager.instance?.PlayTheme(Theme);
+            AudioManager.Instance.PlayTheme(Theme);
             Debug.Log("theme should play btw");
         }
     }
@@ -38,8 +38,8 @@ public class AudioZoneManager : MonoBehaviour
         var player = other.GetComponent<CharacterController2D>();
         if (player != null)
         {
-            AudioManager.instance?.Fade(Theme);
-           // AudioManager.instance?.Stop(Theme1);
+            AudioManager.Instance.Fade(Theme);
+           // AudioManager.instance.Stop(Theme1);
             Debug.Log("theme should stop btw");
         }
     }

--- a/Assets/cwg/Sounds/AudioZoneManager.cs
+++ b/Assets/cwg/Sounds/AudioZoneManager.cs
@@ -28,7 +28,7 @@ public class AudioZoneManager : MonoBehaviour
         var player = other.GetComponent<CharacterController2D>();
         if (player != null)
         {
-            FindObjectOfType<AudioManager>().PlayTheme(Theme);
+            AudioManager.instance?.PlayTheme(Theme);
             Debug.Log("theme should play btw");
         }
     }
@@ -38,8 +38,8 @@ public class AudioZoneManager : MonoBehaviour
         var player = other.GetComponent<CharacterController2D>();
         if (player != null)
         {
-            FindObjectOfType<AudioManager>().Fade(Theme);
-           // FindObjectOfType<AudioManager>().Stop(Theme1);
+            AudioManager.instance?.Fade(Theme);
+           // AudioManager.instance?.Stop(Theme1);
             Debug.Log("theme should stop btw");
         }
     }

--- a/Assets/cwg/cwgpm scripts/CharacterController2D.cs
+++ b/Assets/cwg/cwgpm scripts/CharacterController2D.cs
@@ -130,7 +130,7 @@ public class CharacterController2D : MonoBehaviour
             state = State.Idle;
             receivedItemSprite.sprite = null;
             Debug.Log("finishing recieving item");
-            FindObjectOfType<AudioManager>().Play("ItemGet");
+            AudioManager.instance?.Play("ItemGet");
             //player.inventory.currentItem = null;
         }
     }
@@ -181,7 +181,7 @@ public class CharacterController2D : MonoBehaviour
         if (currentHealth.RuntimeValue > 0)
         {
             StartCoroutine(KnockCo(knockTime, damage));
-            FindObjectOfType<AudioManager>().Play("Oink");
+            AudioManager.instance?.Play("Oink");
         }
         else
         {

--- a/Assets/cwg/cwgpm scripts/CharacterController2D.cs
+++ b/Assets/cwg/cwgpm scripts/CharacterController2D.cs
@@ -130,7 +130,7 @@ public class CharacterController2D : MonoBehaviour
             state = State.Idle;
             receivedItemSprite.sprite = null;
             Debug.Log("finishing recieving item");
-            AudioManager.instance?.Play("ItemGet");
+            AudioManager.Instance.Play("ItemGet");
             //player.inventory.currentItem = null;
         }
     }
@@ -181,7 +181,7 @@ public class CharacterController2D : MonoBehaviour
         if (currentHealth.RuntimeValue > 0)
         {
             StartCoroutine(KnockCo(knockTime, damage));
-            AudioManager.instance?.Play("Oink");
+            AudioManager.Instance.Play("Oink");
         }
         else
         {

--- a/Assets/cwg/cwgpm scripts/OpenCraft.cs
+++ b/Assets/cwg/cwgpm scripts/OpenCraft.cs
@@ -37,7 +37,7 @@ public class OpenCraft : Interactable
                 if (Input.GetKeyDown(KeyCode.Space) && playerInRange)
                 {
                     playerMemory.initialValue = playerPosition;
-            FindObjectOfType<AudioManager>().Play(soundEffectToPlay);
+            AudioManager.instance?.Play(soundEffectToPlay);
             StartCoroutine(FadeCo());
                 }
                 else

--- a/Assets/cwg/cwgpm scripts/OpenCraft.cs
+++ b/Assets/cwg/cwgpm scripts/OpenCraft.cs
@@ -37,7 +37,7 @@ public class OpenCraft : Interactable
                 if (Input.GetKeyDown(KeyCode.Space) && playerInRange)
                 {
                     playerMemory.initialValue = playerPosition;
-            AudioManager.instance?.Play(soundEffectToPlay);
+            AudioManager.Instance.Play(soundEffectToPlay);
             StartCoroutine(FadeCo());
                 }
                 else

--- a/Assets/cwg/cwgpm scripts/SceneTransition.cs
+++ b/Assets/cwg/cwgpm scripts/SceneTransition.cs
@@ -47,7 +47,7 @@ public class SceneTransition : MonoBehaviour
         if(fadeOutPanel !=null)
         {
             Instantiate(fadeOutPanel, Vector3.zero, Quaternion.identity);
-            FindObjectOfType<AudioManager>().Play(soundEffectToPlay);
+            AudioManager.instance?.Play(soundEffectToPlay);
 
         }
         yield return new WaitForSeconds(fadeWait);

--- a/Assets/cwg/cwgpm scripts/SceneTransition.cs
+++ b/Assets/cwg/cwgpm scripts/SceneTransition.cs
@@ -47,7 +47,7 @@ public class SceneTransition : MonoBehaviour
         if(fadeOutPanel !=null)
         {
             Instantiate(fadeOutPanel, Vector3.zero, Quaternion.identity);
-            AudioManager.instance?.Play(soundEffectToPlay);
+            AudioManager.Instance.Play(soundEffectToPlay);
 
         }
         yield return new WaitForSeconds(fadeWait);

--- a/Assets/cwg/cwgpm scripts/ScriptableObjects/Dialogs/DialogNPC.cs
+++ b/Assets/cwg/cwgpm scripts/ScriptableObjects/Dialogs/DialogNPC.cs
@@ -96,7 +96,7 @@ public class DialogNPC : Interactable
                     player.inventory[item2]++;
 
                     //I am hard coding these sound effects in
-                    FindObjectOfType<AudioManager>().Play("ItemGet");
+                    AudioManager.instance?.Play("ItemGet");
                 }
                 if (!noTake)
                 {
@@ -105,7 +105,7 @@ public class DialogNPC : Interactable
 //I am hard coding these sound effects in
 //this needs a different sound effect for 'character taking item'
 
-FindObjectOfType<AudioManager>().Play("Whp");
+AudioManager.instance?.Play("Whp");
                 }
                 onlyOnce = true;
             }

--- a/Assets/cwg/cwgpm scripts/ScriptableObjects/Dialogs/DialogNPC.cs
+++ b/Assets/cwg/cwgpm scripts/ScriptableObjects/Dialogs/DialogNPC.cs
@@ -96,7 +96,7 @@ public class DialogNPC : Interactable
                     player.inventory[item2]++;
 
                     //I am hard coding these sound effects in
-                    AudioManager.instance?.Play("ItemGet");
+                    AudioManager.Instance.Play("ItemGet");
                 }
                 if (!noTake)
                 {
@@ -105,7 +105,7 @@ public class DialogNPC : Interactable
 //I am hard coding these sound effects in
 //this needs a different sound effect for 'character taking item'
 
-AudioManager.instance?.Play("Whp");
+AudioManager.Instance.Play("Whp");
                 }
                 onlyOnce = true;
             }

--- a/Assets/cwg/cwgpm scripts/UI/ImageTime.cs
+++ b/Assets/cwg/cwgpm scripts/UI/ImageTime.cs
@@ -58,7 +58,7 @@ public class ImageTime : MonoBehaviour
             else
             {
                 CustomImage.SetActive(true);
-                FindObjectOfType<AudioManager>().Play(soundEffectToPlay);
+                AudioManager.instance?.Play(soundEffectToPlay);
                 timer = timer - waitTime;
             }
 

--- a/Assets/cwg/cwgpm scripts/UI/ImageTime.cs
+++ b/Assets/cwg/cwgpm scripts/UI/ImageTime.cs
@@ -58,7 +58,7 @@ public class ImageTime : MonoBehaviour
             else
             {
                 CustomImage.SetActive(true);
-                AudioManager.instance?.Play(soundEffectToPlay);
+                AudioManager.Instance.Play(soundEffectToPlay);
                 timer = timer - waitTime;
             }
 

--- a/Assets/cwg/cwgpm scripts/UI/PauseManager.cs
+++ b/Assets/cwg/cwgpm scripts/UI/PauseManager.cs
@@ -38,7 +38,7 @@ public class PauseManager : MonoBehaviour
 
         if (isPaused)
         {
-            AudioManager.instance?.Play(soundEffectToPlay);
+            AudioManager.Instance.Play(soundEffectToPlay);
             pausePanel.SetActive(true);
             mainCanvas.SetActive(false);
             Time.timeScale = 0f;
@@ -46,7 +46,7 @@ public class PauseManager : MonoBehaviour
         }
         else
         {
-            AudioManager.instance?.Play(soundEffectToPlay);
+            AudioManager.Instance.Play(soundEffectToPlay);
             inventoryPanel.SetActive(false);
             pausePanel.SetActive(false);
             mainCanvas.SetActive(true);

--- a/Assets/cwg/cwgpm scripts/UI/PauseManager.cs
+++ b/Assets/cwg/cwgpm scripts/UI/PauseManager.cs
@@ -38,7 +38,7 @@ public class PauseManager : MonoBehaviour
 
         if (isPaused)
         {
-            FindObjectOfType<AudioManager>().Play(soundEffectToPlay);
+            AudioManager.instance?.Play(soundEffectToPlay);
             pausePanel.SetActive(true);
             mainCanvas.SetActive(false);
             Time.timeScale = 0f;
@@ -46,7 +46,7 @@ public class PauseManager : MonoBehaviour
         }
         else
         {
-            FindObjectOfType<AudioManager>().Play(soundEffectToPlay);
+            AudioManager.instance?.Play(soundEffectToPlay);
             inventoryPanel.SetActive(false);
             pausePanel.SetActive(false);
             mainCanvas.SetActive(true);

--- a/Assets/cwg/cwgpm scripts/cwgpm objects/ItemChanger.cs
+++ b/Assets/cwg/cwgpm scripts/cwgpm objects/ItemChanger.cs
@@ -77,7 +77,7 @@ public class ItemChanger : Interactable
         //makes it so character cannot move during this coroutine
         player.RaiseItem(emptySprite);
 
-        FindObjectOfType<AudioManager>().Play(soundEffectToPlay);
+        AudioManager.instance?.Play(soundEffectToPlay);
         yield return new WaitForSeconds(0.1f);
         effect.SetBool("Effect", true);
         yield return new WaitForSeconds(2f);
@@ -87,7 +87,7 @@ public class ItemChanger : Interactable
 
         player.RaiseItem(null);
 
-        //FindObjectOfType<AudioManager>().Play("ItemGet");
+        //AudioManager.instance?.Play("ItemGet");
         //not needed: raise item null creates the above sound effect
         effect.SetBool("Effect", false);
 

--- a/Assets/cwg/cwgpm scripts/cwgpm objects/ItemChanger.cs
+++ b/Assets/cwg/cwgpm scripts/cwgpm objects/ItemChanger.cs
@@ -77,7 +77,7 @@ public class ItemChanger : Interactable
         //makes it so character cannot move during this coroutine
         player.RaiseItem(emptySprite);
 
-        AudioManager.instance?.Play(soundEffectToPlay);
+        AudioManager.Instance.Play(soundEffectToPlay);
         yield return new WaitForSeconds(0.1f);
         effect.SetBool("Effect", true);
         yield return new WaitForSeconds(2f);
@@ -87,7 +87,7 @@ public class ItemChanger : Interactable
 
         player.RaiseItem(null);
 
-        //AudioManager.instance?.Play("ItemGet");
+        //AudioManager.instance.Play("ItemGet");
         //not needed: raise item null creates the above sound effect
         effect.SetBool("Effect", false);
 

--- a/Assets/cwg/cwgpm scripts/cwgpm objects/Sign.cs
+++ b/Assets/cwg/cwgpm scripts/cwgpm objects/Sign.cs
@@ -30,7 +30,7 @@ public class Sign : MonoBehaviour
             }
             else
             {
-                FindObjectOfType<AudioManager>().Play(soundEffectToPlay);
+                AudioManager.instance?.Play(soundEffectToPlay);
                 dialogBox.SetActive(true);
                 dialogText.text = dialog;
             }

--- a/Assets/cwg/cwgpm scripts/cwgpm objects/Sign.cs
+++ b/Assets/cwg/cwgpm scripts/cwgpm objects/Sign.cs
@@ -30,7 +30,7 @@ public class Sign : MonoBehaviour
             }
             else
             {
-                AudioManager.instance?.Play(soundEffectToPlay);
+                AudioManager.Instance.Play(soundEffectToPlay);
                 dialogBox.SetActive(true);
                 dialogText.text = dialog;
             }

--- a/Assets/cwg/cwgpm scripts/cwgpm objects/buttonSwitch.cs
+++ b/Assets/cwg/cwgpm scripts/cwgpm objects/buttonSwitch.cs
@@ -29,7 +29,7 @@ public class buttonSwitch : Interactable
         {
             animator1.SetBool("Switch", false);
             animator2.SetBool("Switch", false);
-            FindObjectOfType<AudioManager>().Stop("Conveyor");
+            AudioManager.instance?.Stop("Conveyor");
             hideOnSwitch1.SetActive(false);
             hideOnSwitch2.SetActive(false);
         }
@@ -37,7 +37,7 @@ public class buttonSwitch : Interactable
         {
             animator1.SetBool("Switch", true);
             animator2.SetBool("Switch", true);
-FindObjectOfType<AudioManager>().Play("Conveyor");
+AudioManager.instance?.Play("Conveyor");
             hideOnSwitch1.SetActive(true);
             hideOnSwitch2.SetActive(true);
         }

--- a/Assets/cwg/cwgpm scripts/cwgpm objects/buttonSwitch.cs
+++ b/Assets/cwg/cwgpm scripts/cwgpm objects/buttonSwitch.cs
@@ -29,7 +29,7 @@ public class buttonSwitch : Interactable
         {
             animator1.SetBool("Switch", false);
             animator2.SetBool("Switch", false);
-            AudioManager.instance?.Stop("Conveyor");
+            AudioManager.Instance.Stop("Conveyor");
             hideOnSwitch1.SetActive(false);
             hideOnSwitch2.SetActive(false);
         }
@@ -37,7 +37,7 @@ public class buttonSwitch : Interactable
         {
             animator1.SetBool("Switch", true);
             animator2.SetBool("Switch", true);
-AudioManager.instance?.Play("Conveyor");
+AudioManager.Instance.Play("Conveyor");
             hideOnSwitch1.SetActive(true);
             hideOnSwitch2.SetActive(true);
         }

--- a/Assets/cwg/cwgpm scripts/snowPile.cs
+++ b/Assets/cwg/cwgpm scripts/snowPile.cs
@@ -38,7 +38,7 @@ public class snowPile : Interactable
         {
             if (!isDug)
             {
-                AudioManager.instance?.Play(soundEffectToPlay);
+                AudioManager.Instance.Play(soundEffectToPlay);
                 DigSnow();
             }
             else
@@ -72,7 +72,7 @@ public class snowPile : Interactable
         storedDug.RuntimeValue = isDug;
 
         
-        //AudioManager.instance?.Play("ItemGet");
+        //AudioManager.instance.Play("ItemGet");
     }
 
     private void SnowDug()

--- a/Assets/cwg/cwgpm scripts/snowPile.cs
+++ b/Assets/cwg/cwgpm scripts/snowPile.cs
@@ -38,7 +38,7 @@ public class snowPile : Interactable
         {
             if (!isDug)
             {
-                FindObjectOfType<AudioManager>().Play(soundEffectToPlay);
+                AudioManager.instance?.Play(soundEffectToPlay);
                 DigSnow();
             }
             else
@@ -72,7 +72,7 @@ public class snowPile : Interactable
         storedDug.RuntimeValue = isDug;
 
         
-        //FindObjectOfType<AudioManager>().Play("ItemGet");
+        //AudioManager.instance?.Play("ItemGet");
     }
 
     private void SnowDug()

--- a/Assets/schwer-scripts-master/schwer-scripts/ItemSystem/ItemDrop.cs
+++ b/Assets/schwer-scripts-master/schwer-scripts/ItemSystem/ItemDrop.cs
@@ -11,11 +11,11 @@ public class ItemDrop : MonoBehaviour
         var player = other.GetComponent<CharacterController2D>();
         if (player != null)
         {
-            //AudioManager.instance?.Play("itemget");
+            //AudioManager.instance.Play("itemget");
             player.inventory[item]++;
 
-            //AudioManager.instance?.Play("ItemGet");
-            AudioManager.instance?.Play(soundEffectToPlay);
+            //AudioManager.instance.Play("ItemGet");
+            AudioManager.Instance.Play(soundEffectToPlay);
 
             Destroy(this.gameObject);
 

--- a/Assets/schwer-scripts-master/schwer-scripts/ItemSystem/ItemDrop.cs
+++ b/Assets/schwer-scripts-master/schwer-scripts/ItemSystem/ItemDrop.cs
@@ -11,11 +11,11 @@ public class ItemDrop : MonoBehaviour
         var player = other.GetComponent<CharacterController2D>();
         if (player != null)
         {
-            //FindObjectOfType<AudioManager>().Play("itemget");
+            //AudioManager.instance?.Play("itemget");
             player.inventory[item]++;
 
-            //FindObjectOfType<AudioManager>().Play("ItemGet");
-            FindObjectOfType<AudioManager>().Play(soundEffectToPlay);
+            //AudioManager.instance?.Play("ItemGet");
+            AudioManager.instance?.Play(soundEffectToPlay);
 
             Destroy(this.gameObject);
 


### PR DESCRIPTION
### `keyBox` (prefab) / `textItem` (MonoBehaviour)
- Removed missing component from prefab
- `textItem` was deleted in commit 4remy/cwgpm-2@1eedacd5
- Missing component would log a vague warning in the console

### `AudioManager`
- Inherit from `DDOLSingleton` (schwer-scripts)
- Created `FindSound` function to reduce code duplication
- Scripts using `AudioManager` use `AudioManager.Instance` to ensure usage of singleton instance

**Note:** only one 'theme' can ever be played per session, since `themePlaying` is never set to `false` (unintentional?)