### PR TITLE
Restore Save Data Reset Functionality

### DIFF
--- a/Assets/_schwer/Editor/GameSaveManagerInspector.cs
+++ b/Assets/_schwer/Editor/GameSaveManagerInspector.cs
@@ -6,6 +6,10 @@ public class GameSaveManagerInspector : Editor {
     public override void OnInspectorGUI() {
         var gsm = (GameSaveManager)target;
 
+        if (GUILayout.Button("Open Save Location")) {
+            Application.OpenURL(Application.persistentDataPath);
+        }
+
         EditorGUI.BeginDisabledGroup(!Application.isPlaying);
         if (GUILayout.Button("Save")) {
             gsm.SaveScriptables();

--- a/Assets/cwg/Prefabs cwgpm/PauseCanvas.prefab
+++ b/Assets/cwg/Prefabs cwgpm/PauseCanvas.prefab
@@ -120,9 +120,9 @@ MonoBehaviour:
   m_OnClick:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: GameSaveManager, Assembly-CSharp
-        m_MethodName: ResetScriptables
+      - m_Target: {fileID: 2315304840646276402}
+        m_TargetAssemblyTypeName: PauseManager, Assembly-CSharp
+        m_MethodName: ResetSave
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -251,7 +251,19 @@ MonoBehaviour:
   m_TargetGraphic: {fileID: 2315304839846568077}
   m_OnClick:
     m_PersistentCalls:
-      m_Calls: []
+      m_Calls:
+      - m_Target: {fileID: 2315304840646276402}
+        m_TargetAssemblyTypeName: PauseManager, Assembly-CSharp
+        m_MethodName: Save
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
 --- !u!1 &2315304839884696337
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/cwg/Prefabs cwgpm/UI prefabs/PauseCanvas.prefab
+++ b/Assets/cwg/Prefabs cwgpm/UI prefabs/PauseCanvas.prefab
@@ -532,10 +532,11 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   pausePanel: {fileID: 37173835667068455}
-  inventoryPanel: {fileID: 37173835952287510}
+  inventoryPanel: {fileID: 0}
   mainCanvas: {fileID: 0}
   mainMenu: StartMenu
   usingPausePanel: 0
+  soundEffectToPlay: Settings
 --- !u!1 &37173835667068455
 GameObject:
   m_ObjectHideFlags: 0
@@ -812,7 +813,7 @@ GameObject:
   - component: {fileID: 37173835952287508}
   - component: {fileID: 37173835952287530}
   m_Layer: 5
-  m_Name: Inventory Panel
+  m_Name: BADInventory Panel
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -1430,7 +1431,19 @@ MonoBehaviour:
   m_TargetGraphic: {fileID: 37173836441590147}
   m_OnClick:
     m_PersistentCalls:
-      m_Calls: []
+      m_Calls:
+      - m_Target: {fileID: 37173835647192124}
+        m_TargetAssemblyTypeName: PauseManager, Assembly-CSharp
+        m_MethodName: Save
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
 --- !u!1 &37173836784583245
 GameObject:
   m_ObjectHideFlags: 0
@@ -2486,9 +2499,9 @@ MonoBehaviour:
   m_OnClick:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: GameSaveManager, Assembly-CSharp
-        m_MethodName: ResetScriptables
+      - m_Target: {fileID: 37173835647192124}
+        m_TargetAssemblyTypeName: PauseManager, Assembly-CSharp
+        m_MethodName: ResetSave
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}

--- a/Assets/cwg/cwgpm scripts/ScriptableObjects/BoolValue.cs
+++ b/Assets/cwg/cwgpm scripts/ScriptableObjects/BoolValue.cs
@@ -1,29 +1,12 @@
-﻿//using System;
-using System.Collections;
-using System.Collections.Generic;
-using UnityEngine;
+﻿using UnityEngine;
 
 [CreateAssetMenu]
 //[System.Serializable]
 public class BoolValue : ScriptableObject
-    //, ISerializationCallbackReceiver
 {
-    public bool initialValue;
-    //  [NonSerialized]
-    public bool RuntimeValue;
-
-/*
-    public void OnAfterDeserialize()
-    {
-        RuntimeValue = initialValue;
-    }
-
-    public void OnBeforeSerialize()
-    { }
-*/
-    //this did not help
-    //private void OnEnable()
-    // {
-    //    initialValue = RuntimeValue;
-    //}
+    /// <summary>
+    /// Default value for new/reset saves. Do not use this anywhere else.
+    /// </summary>
+    [Tooltip("Default value for new/reset saves")] public bool initialValue;
+    [Tooltip("Value to use in game")] public bool RuntimeValue;
 }

--- a/Assets/cwg/cwgpm scripts/ScriptableObjects/FloatValue.cs
+++ b/Assets/cwg/cwgpm scripts/ScriptableObjects/FloatValue.cs
@@ -1,13 +1,12 @@
-﻿using System.Collections;
-using System.Collections.Generic;
-using UnityEngine;
+﻿using UnityEngine;
 
 [CreateAssetMenu]
 [System.Serializable]
 public class FloatValue : ScriptableObject
 {
-    public float initialValue;
-
-    public float RuntimeValue;
-
+    /// <summary>
+    /// Default value for new/reset saves. Do not use this anywhere else.
+    /// </summary>
+    [Tooltip("Default value for new/reset saves")] public float initialValue;
+    [Tooltip("Value to use in game")] public float RuntimeValue;
 }

--- a/Assets/cwg/cwgpm scripts/ScriptableObjects/PlayerStuff/PlayerHealth.asset
+++ b/Assets/cwg/cwgpm scripts/ScriptableObjects/PlayerStuff/PlayerHealth.asset
@@ -13,4 +13,4 @@ MonoBehaviour:
   m_Name: PlayerHealth
   m_EditorClassIdentifier: 
   initialValue: 4
-  RuntimeValue: 8
+  RuntimeValue: 4

--- a/Assets/cwg/cwgpm scripts/UI/GameSaveManager.cs
+++ b/Assets/cwg/cwgpm scripts/UI/GameSaveManager.cs
@@ -3,29 +3,14 @@ using System.IO;
 using UnityEngine;
 using Schwer.ItemSystem;
 using Schwer.IO;
+using Schwer;
 
-public class GameSaveManager : MonoBehaviour
+public class GameSaveManager : DDOLSingleton<GameSaveManager>
 {
-    public static GameSaveManager gameSave;
     [SerializeField] private ItemDatabase itemDB = default;
-    public List<ScriptableObject> objects = new List<ScriptableObject>();
+    [SerializeField] private List<ScriptableObject> objects = new List<ScriptableObject>();
     [SerializeField] private IntListSO discoveredRecipes = default;
     [SerializeField] private InventorySO[] inventories = default;
-
-    /*
-    private void Awake()
-    {
-        if(gameSave == null)
-        {
-            gameSave = this;
-        }
-        else
-        {
-            Destroy(this.gameObject);
-        }
-        DontDestroyOnLoad(this);
-    }
-    */
 
     public void ResetScriptables()
     {
@@ -83,7 +68,8 @@ public class GameSaveManager : MonoBehaviour
         }
     }
 
-    private void LoadInventories() {
+    private void LoadInventories()
+    {
         for (int i = 0; i < inventories.Length; i++)
         {
             var path = $"{Application.persistentDataPath}/{i}.inv";
@@ -94,9 +80,11 @@ public class GameSaveManager : MonoBehaviour
         }
     }
 
-    private void LoadRecipes() {
+    private void LoadRecipes()
+    {
         var path = $"{Application.persistentDataPath}/recipes.dat";
-        if (File.Exists(path)) {
+        if (File.Exists(path))
+        {
             discoveredRecipes.ints = BinaryIO.ReadFile<List<int>>(path);
         }
     }

--- a/Assets/cwg/cwgpm scripts/UI/HeartManager.cs
+++ b/Assets/cwg/cwgpm scripts/UI/HeartManager.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections;
-using System.Collections.Generic;
-using UnityEngine;
+﻿using UnityEngine;
 using UnityEngine.UI;
 
 public class HeartManager : MonoBehaviour
@@ -12,32 +10,34 @@ public class HeartManager : MonoBehaviour
     public FloatValue heartContainers;
     public FloatValue playerCurrentHealth;
 
-    // Start is called before the first frame update
-    void Start()
+    private void Start()
     {
         InitHearts();
     }
+
     public void InitHearts()
     {
-        for(int i = 0; i < heartContainers.initialValue; i ++)
+        for (int i = 0; i < heartContainers.RuntimeValue; i++)
         {
-            if(i < hearts.Length)
+            if (i < hearts.Length)
             {
                 hearts[i].gameObject.SetActive(true);
                 hearts[i].sprite = fullHeart;
             }
         }
     }
+
     public void UpdateHearts()
     {
         float tempHealth = playerCurrentHealth.RuntimeValue / 2;
-        for (int i = 0; i < heartContainers.RuntimeValue; i ++)
+        for (int i = 0; i < heartContainers.RuntimeValue; i++)
         {
-            if(i <= tempHealth-1)
+            if (i <= tempHealth - 1)
             {
                 //full heart
                 hearts[i].sprite = fullHeart;
-            }else if( i >= tempHealth)
+            }
+            else if (i >= tempHealth)
             {
                 //empty heart
                 hearts[i].sprite = emptyHeart;
@@ -49,4 +49,4 @@ public class HeartManager : MonoBehaviour
             }
         }
     }
-} 
+}

--- a/Assets/cwg/cwgpm scripts/UI/PauseManager.cs
+++ b/Assets/cwg/cwgpm scripts/UI/PauseManager.cs
@@ -51,6 +51,11 @@ public class PauseManager : MonoBehaviour
         }
     }
 
+    // Called by UI button
+    public void Save() => GameSaveManager.Instance?.SaveScriptables();
+    // Called by UI button
+    public void ResetSave() => GameSaveManager.Instance?.ResetScriptables();
+
     public void QuitToMain()
     {
         SceneManager.LoadScene(mainMenu);

--- a/Assets/cwg/cwgpm scripts/UI/PauseManager.cs
+++ b/Assets/cwg/cwgpm scripts/UI/PauseManager.cs
@@ -1,11 +1,8 @@
-﻿using System.Collections;
-using System.Collections.Generic;
-using UnityEngine;
+﻿using UnityEngine;
 using UnityEngine.SceneManagement;
- 
+
 public class PauseManager : MonoBehaviour
 {
-
     private bool isPaused;
     public GameObject pausePanel;
     public GameObject inventoryPanel;
@@ -16,35 +13,23 @@ public class PauseManager : MonoBehaviour
 
     private bool busyUI;
 
-
-    // Start is called before the first frame update
-    void Start()
+    private void Start()
     {
         isPaused = false;
         pausePanel.SetActive(false);
         inventoryPanel.SetActive(false);
         usingPausePanel = false;
-
     }
 
-    // Update is called once per frame
-    void Update()
+    private void Update()
     {
-        if (Input.GetButtonDown("Pause"))
+        if (Input.GetButtonDown("Pause") && !busyUI)
         {
-            if (!busyUI)
-            {
-                ChangePause();
-            }
-            else
-            {
-                return;
-            }
-
+            ChangePause();
         }
     }
 
-   public void ChangePause()
+    public void ChangePause()
     {
         isPaused = !isPaused;
 
@@ -64,7 +49,6 @@ public class PauseManager : MonoBehaviour
             mainCanvas.SetActive(true);
             Time.timeScale = 1f;
         }
-
     }
 
     public void QuitToMain()
@@ -76,7 +60,7 @@ public class PauseManager : MonoBehaviour
     public void SwitchPanels()
     {
         usingPausePanel = !usingPausePanel;
-        if(usingPausePanel)
+        if (usingPausePanel)
         {
             pausePanel.SetActive(true);
             mainCanvas.SetActive(false);

--- a/Assets/cwg/cwgpm scripts/cwgpm objects/Heart.cs
+++ b/Assets/cwg/cwgpm scripts/cwgpm objects/Heart.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections;
-using System.Collections.Generic;
-using UnityEngine;
+﻿using UnityEngine;
 
 public class Heart : powerUp
 {
@@ -9,27 +7,15 @@ public class Heart : powerUp
     public float amountToIncrease;
     public string soundEffectToPlay;
 
-    // Start is called before the first frame update
-    void Start()
-    {
-
-    }
-
-    // Update is called once per frame
-    void Update()
-    {
-
-    }
-
     public void OnTriggerEnter2D(Collider2D other)
     {
         if (other.CompareTag("Player") && !other.isTrigger)
         {
             AudioManager.Instance.Play(soundEffectToPlay);
             playerHealth.RuntimeValue += amountToIncrease;
-            if(playerHealth.initialValue > heartContainers.RuntimeValue * 2f)
+            if(playerHealth.RuntimeValue > heartContainers.RuntimeValue * 2f)
             {
-                playerHealth.initialValue = heartContainers.RuntimeValue * 2f;
+                playerHealth.RuntimeValue = heartContainers.RuntimeValue * 2f;
             }
             powerUpSignal.Raise();
             Destroy(this.gameObject);

--- a/Assets/cwg/scenes/StartMenu.unity
+++ b/Assets/cwg/scenes/StartMenu.unity
@@ -554,7 +554,7 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    m_TransformParent: {fileID: 1415425165}
+    m_TransformParent: {fileID: 0}
     m_Modifications:
     - target: {fileID: 399764430589016217, guid: b492ca805184a462a8c166dd4e939521,
         type: 3}
@@ -564,22 +564,37 @@ PrefabInstance:
     - target: {fileID: 399764430589016223, guid: b492ca805184a462a8c166dd4e939521,
         type: 3}
       propertyPath: m_RootOrder
-      value: 9
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 399764430589016223, guid: b492ca805184a462a8c166dd4e939521,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 2.4
+      objectReference: {fileID: 0}
+    - target: {fileID: 399764430589016223, guid: b492ca805184a462a8c166dd4e939521,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 2.4
+      objectReference: {fileID: 0}
+    - target: {fileID: 399764430589016223, guid: b492ca805184a462a8c166dd4e939521,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 2.4
       objectReference: {fileID: 0}
     - target: {fileID: 399764430589016223, guid: b492ca805184a462a8c166dd4e939521,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 0.20667145
+      value: 960.49603
       objectReference: {fileID: 0}
     - target: {fileID: 399764430589016223, guid: b492ca805184a462a8c166dd4e939521,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.29331023
+      value: 540.7039
       objectReference: {fileID: 0}
     - target: {fileID: 399764430589016223, guid: b492ca805184a462a8c166dd4e939521,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: -1826.5206
+      value: -4383.65
       objectReference: {fileID: 0}
     - target: {fileID: 399764430589016223, guid: b492ca805184a462a8c166dd4e939521,
         type: 3}
@@ -589,17 +604,17 @@ PrefabInstance:
     - target: {fileID: 399764430589016223, guid: b492ca805184a462a8c166dd4e939521,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 399764430589016223, guid: b492ca805184a462a8c166dd4e939521,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 399764430589016223, guid: b492ca805184a462a8c166dd4e939521,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 399764430589016223, guid: b492ca805184a462a8c166dd4e939521,
         type: 3}
@@ -773,12 +788,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 761275943}
   m_CullTransparentMesh: 0
---- !u!4 &775889951 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 399764430589016223, guid: b492ca805184a462a8c166dd4e939521,
-    type: 3}
-  m_PrefabInstance: {fileID: 605335713}
-  m_PrefabAsset: {fileID: 0}
 --- !u!114 &775889952 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 399764430589016222, guid: b492ca805184a462a8c166dd4e939521,
@@ -1370,7 +1379,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: -91.00195, y: 4.8812866}
+  m_AnchoredPosition: {x: -91.00195, y: 4.8813477}
   m_SizeDelta: {x: -137.7608, y: 41.67325}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1338952737
@@ -1451,7 +1460,6 @@ RectTransform:
   - {fileID: 1310661910}
   - {fileID: 1678761461}
   - {fileID: 440649209}
-  - {fileID: 775889951}
   m_Father: {fileID: 0}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -2524,7 +2532,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 2
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1979822197
 GameObject:

--- a/Assets/cwg/scenes/cwgpm.unity
+++ b/Assets/cwg/scenes/cwgpm.unity
@@ -12445,11 +12445,6 @@ PrefabInstance:
       propertyPath: m_Name
       value: PauseCanvas
       objectReference: {fileID: 0}
-    - target: {fileID: 37173835647192123, guid: 82ca771f5e196411d9430edc5ab548d3,
-        type: 3}
-      propertyPath: m_IsActive
-      value: 1
-      objectReference: {fileID: 0}
     - target: {fileID: 37173835647192124, guid: 82ca771f5e196411d9430edc5ab548d3,
         type: 3}
       propertyPath: mainCanvas
@@ -12460,11 +12455,6 @@ PrefabInstance:
       propertyPath: inventoryPanel
       value: 
       objectReference: {fileID: 1742999726}
-    - target: {fileID: 37173835647192124, guid: 82ca771f5e196411d9430edc5ab548d3,
-        type: 3}
-      propertyPath: soundEffectToPlay
-      value: Settings
-      objectReference: {fileID: 0}
     - target: {fileID: 37173835647192127, guid: 82ca771f5e196411d9430edc5ab548d3,
         type: 3}
       propertyPath: m_Pivot.x
@@ -12569,61 +12559,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 37173835667068455, guid: 82ca771f5e196411d9430edc5ab548d3,
-        type: 3}
-      propertyPath: m_IsActive
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 37173835952287510, guid: 82ca771f5e196411d9430edc5ab548d3,
-        type: 3}
-      propertyPath: m_Name
-      value: BADInventory Panel
-      objectReference: {fileID: 0}
-    - target: {fileID: 37173835952287511, guid: 82ca771f5e196411d9430edc5ab548d3,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: -9
-      objectReference: {fileID: 0}
-    - target: {fileID: 37173836441590146, guid: 82ca771f5e196411d9430edc5ab548d3,
-        type: 3}
-      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.size
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 37173836441590146, guid: 82ca771f5e196411d9430edc5ab548d3,
-        type: 3}
-      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 37173836441590146, guid: 82ca771f5e196411d9430edc5ab548d3,
-        type: 3}
-      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Target
-      value: 
-      objectReference: {fileID: 0}
-    - target: {fileID: 37173836441590146, guid: 82ca771f5e196411d9430edc5ab548d3,
-        type: 3}
-      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_CallState
-      value: 2
-      objectReference: {fileID: 0}
-    - target: {fileID: 37173836441590146, guid: 82ca771f5e196411d9430edc5ab548d3,
-        type: 3}
-      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
-      value: SaveScriptables
-      objectReference: {fileID: 0}
-    - target: {fileID: 37173836441590146, guid: 82ca771f5e196411d9430edc5ab548d3,
-        type: 3}
-      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_TargetAssemblyTypeName
-      value: GameSaveManager, Assembly-CSharp
-      objectReference: {fileID: 0}
-    - target: {fileID: 37173836441590146, guid: 82ca771f5e196411d9430edc5ab548d3,
-        type: 3}
-      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgumentAssemblyTypeName
-      value: UnityEngine.Object, UnityEngine
-      objectReference: {fileID: 0}
-    - target: {fileID: 1066711907703014702, guid: 82ca771f5e196411d9430edc5ab548d3,
-        type: 3}
-      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Target
-      value: 
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 82ca771f5e196411d9430edc5ab548d3, type: 3}
@@ -14417,17 +14352,17 @@ PrefabInstance:
     - target: {fileID: 5878690872114416838, guid: 13cd19ac97de84e41951ac3a599d8a1a,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 0.29000044
+      value: 0.16445446
       objectReference: {fileID: 0}
     - target: {fileID: 5878690872114416838, guid: 13cd19ac97de84e41951ac3a599d8a1a,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 2.1
+      value: -0.23228733
       objectReference: {fileID: 0}
     - target: {fileID: 5878690872114416838, guid: 13cd19ac97de84e41951ac3a599d8a1a,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: -10
+      value: -19301.1
       objectReference: {fileID: 0}
     - target: {fileID: 5878690872114416838, guid: 13cd19ac97de84e41951ac3a599d8a1a,
         type: 3}

--- a/Assets/cwg/scenes/cwgpmScene2.unity
+++ b/Assets/cwg/scenes/cwgpmScene2.unity
@@ -12889,18 +12889,6 @@ GameObject:
     type: 3}
   m_PrefabInstance: {fileID: 8358473222974702023}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &1728089588 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 399764430589016222, guid: b492ca805184a462a8c166dd4e939521,
-    type: 3}
-  m_PrefabInstance: {fileID: 399764431008478570}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1156765256}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: b3bf3d67cac9e43a893205464fbc470d, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1 &1739983182
 GameObject:
   m_ObjectHideFlags: 0
@@ -13298,17 +13286,17 @@ PrefabInstance:
     - target: {fileID: 2469573257613326820, guid: fe435754069654f829b5a6efe2c5b18e,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: -0.8411857
+      value: 0.16445446
       objectReference: {fileID: 0}
     - target: {fileID: 2469573257613326820, guid: fe435754069654f829b5a6efe2c5b18e,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.07394242
+      value: -0.23228733
       objectReference: {fileID: 0}
     - target: {fileID: 2469573257613326820, guid: fe435754069654f829b5a6efe2c5b18e,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: -10
+      value: -19301.1
       objectReference: {fileID: 0}
     - target: {fileID: 2469573257613326820, guid: fe435754069654f829b5a6efe2c5b18e,
         type: 3}
@@ -15829,11 +15817,6 @@ PrefabInstance:
       propertyPath: m_SizeDelta.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2315304840623419177, guid: f55e62a2dab5f49e6acf451cb1a2c4e1,
-        type: 3}
-      propertyPath: m_IsActive
-      value: 0
-      objectReference: {fileID: 0}
     - target: {fileID: 2315304840646276401, guid: f55e62a2dab5f49e6acf451cb1a2c4e1,
         type: 3}
       propertyPath: m_Pivot.x
@@ -15954,11 +15937,6 @@ PrefabInstance:
       propertyPath: m_Name
       value: PauseCanvas
       objectReference: {fileID: 0}
-    - target: {fileID: 2315304840646276405, guid: f55e62a2dab5f49e6acf451cb1a2c4e1,
-        type: 3}
-      propertyPath: m_IsActive
-      value: 1
-      objectReference: {fileID: 0}
     - target: {fileID: 2315304840891110411, guid: f55e62a2dab5f49e6acf451cb1a2c4e1,
         type: 3}
       propertyPath: m_AnchorMax.x
@@ -15989,11 +15967,6 @@ PrefabInstance:
       propertyPath: m_IsActive
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3343980723795622944, guid: f55e62a2dab5f49e6acf451cb1a2c4e1,
-        type: 3}
-      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Target
-      value: 
-      objectReference: {fileID: 1728089588}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: f55e62a2dab5f49e6acf451cb1a2c4e1, type: 3}
 --- !u!1001 &2391559289078133719


### PR DESCRIPTION
## Restore Save Data Reset Functionality

### `GameSaveManager`
- Updated `GameSaveManagerInspector` so that viewing a `GameSaveManager` instance now shows a button to open the save folder for ease of access
- `GameSaveManager` is now a singleton marked as `DontDestroyOnLoad`
    - Some scenes don't have an instance of `GameSaveManager`, so save/reset buttons in the pause menu may fail silently if a scene with a `GameSaveManager` instance is never loaded
- `ResetScriptables` now resets scriptable object values back to an arbitrary default value *(in addition to deleting the corresponding files)*
    - Discovered recipes (`IntListSO`) is cleared
    - Inventories (`InventorySO`) are cleared
    - Coins (`CoinCounter`) is set to `0`
    - `BoolValue`s and `FloatValue`s have their `RuntimeValue` set to their `initialValue`
        - ∴ `RuntimeValue` should be considered accessible and modifiable from anywhere, whereas `initialValue` should ***only*** be adjusted via the Inspector to set the value for a 'default' save
        - `HeartManager` and `Heart` have been updated to reflect this

### `PauseManager`
- `PauseManager` now contains its own wrapper functions for saving/resetting to make prefab button events self-contained *(i.e. don't have to assign a `GameSaveManager` reference prefab instance)*

**Note:** there are two `PauseCanvas.prefab`s with differing structures. Both appear to be in use. *(I've updated both, but it's probably best to determine which one should be kept and delete the other)*